### PR TITLE
Update README.md removed EmailEngine, no longer open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ A curated list of resources on Email tools, server, framework, technology...
 
 ### Inbox API
 
-- [EmailEngine App](https://emailengine.app/) - Headless email client that makes IMAP and SMTP resources available over REST
-
 ### Forwarding
 
 - [Forward Email](https://github.com/forwardemail/free-email-forwarding) - The best free email forwarding for custom domains. Visit our website to get started (SMTP server)


### PR DESCRIPTION
https://github.com/postalsys/emailengine/blob/master/LICENSE_EMAILENGINE.txt commerical license required and enforced in code.  $895/yr