### PR TITLE
Link mailinabox to the Github Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [Erooster Email Server](https://github.com/erooster-mail/erooster) -  A mail suite written in rust meant to be easy to use. 
 - [Zimbra Open Source Edition](https://github.com/Zimbra/zm-build) - A full featured email service.
 - [Modoboa](https://modoboa.org/en/) - Modoboa brings together Open Source's finest in a single interface.
-- [Mailinabox](https://mailinabox.email/) - Mail-in-a-Box helps individuals take back control of their email by defining a one-click, easy-to-deploy SMTP+everything else server: a mail server in a box.
+- [Mailinabox](https://github.com/mail-in-a-box/mailinabox) - Mail-in-a-Box helps individuals take back control of their email by defining a one-click, easy-to-deploy SMTP+everything else server: a mail server in a box.
 - [Excision-Mail](https://github.com/Excision-Mail/Excision-Mail) -  Fullstack, security focused, personal mail server based on OpenSMTPD for OpenBSD `ISC License`
 - [Docker Mailserver](https://github.com/docker-mailserver/docker-mailserver) -  Production-ready fullstack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.) running inside a container.  - `MIT`
 


### PR DESCRIPTION
As the title says. I find it more convenient and reliable to get sent to the github repo since I expect to see the opensource project first.