### PR TITLE
Add IntoDNS.ai - DNS & email security scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [Mailgoose](https://github.com/CERT-Polska/mailgoose) -  A web application that allows the users to check whether their SPF, DMARC and DKIM configuration is set up correctly. - `BSD 3-Clause "New" or "Revised" License`, `Python`
 - [mxcheck](https://github.com/steffenfritz/mxcheck) -  mxcheck is an info and security scanner for e-mail servers. `GPL v-3`, `Go`
 - [Spamhaus-Intelligence-API-CLI](https://github.com/Mindbaz/Spamhaus-Intelligence-API-CLI) -  CLI to query Spamhaus Intelligence API `GPL v-3`, `Python`
+- [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, BIMI, MTA-STS and 40+ blacklists with AI-powered fix suggestions. No signup required.
 
 
 ### DMARC


### PR DESCRIPTION
Adding IntoDNS.ai to the Security Check section.

Free DNS and email security scanner — checks SPF, DKIM, DMARC, DNSSEC, BIMI, MTA-STS and 40+ blacklists. No signup needed, just enter a domain.

I know this list focuses on open-source — IntoDNS.ai is a free hosted service (not open-source yet), but it complements the other security check tools well. Happy to remove if it doesn't fit.

— Jeroen, Cobytes B.V.