### PR TITLE
Add DeliverIQ MCP under Email Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [python-email-validator](https://github.com/JoshData/python-email-validator) -  A robust email syntax and deliverability validation library for Python.  `The Unlicense`, `Python`
 - [validate-email](https://github.com/centminmod/validate-emails) -  Self-hosted email verification script to clean up bad invalid email address lists. Supports various commercial email verification provider APIs all in one script - `PHP`
 - [Selfsend - email-sanitizer-api](https://github.com/SelfSend/email-sanitizer-api) - A high-performance and secure REST/GraphQL API built with Rust, MongoDB & Redis for cleaning email subscriber lists. Maintains sender reputation by validating, deduplicating, and pruning inactive emails.  - `MIT`, `Rust`
+- [DeliverIQ MCP](https://github.com/Davison-Francis/min8t-sdks) - MCP (Model Context Protocol) server exposing 12 email-deliverability tools to AI agents like Claude Desktop and Cursor. 21 checks across 5 stages (RFC 5322 syntax, disposable domain detection on 164k+ domains, SMTP handshake with catch-all probe, 50 DNSBL zones, DMARC/SPF/DKIM analysis, spam-trap heuristic scoring). On npm as `@deliveriq/mcp`. - `MIT`, `Typescript`
 
 ### Reputation
 


### PR DESCRIPTION
## Summary

- Adds **DeliverIQ MCP** to **Deliverability → Email Verification**
- One-line entry, alphabetical order preserved within the section
- Brings an AI-agent (Model Context Protocol) angle to the list — fits the same category as Reacher / Email-Verifier / Truemail but exposes a 21-check pipeline as composable tools that Claude Desktop / Cursor / other LLM clients can orchestrate

## Why this fits the list

- **Open source**: MIT licensed at https://github.com/Davison-Francis/min8t-sdks
- **Maintained**: actively developed, on npm at https://www.npmjs.com/package/@deliveriq/mcp
- **Email-deliverability scope**: 21 checks across 5 stages (RFC 5322 format, 164k+ disposable domain DB, SMTP handshake with catch-all probe, 50 DNSBL zones including Spamhaus/SpamCop/SURBL/SORBS, RDAP domain age, HIBP breach, 15 DKIM selectors, 6-standard infra score covering SPF/DKIM/DMARC/MTA-STS/BIMI/TLS-RPT, spam-trap heuristic scoring on 13 weighted signals)
- **Listed elsewhere**: Anthropic's official [MCP Registry](https://registry.modelcontextprotocol.io/), [Glama](https://glama.ai/mcp/servers/Davison-Francis/min8t-sdks), [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)

Happy to adjust description, formatting, or location if you'd prefer it elsewhere — let me know!