### PR TITLE
Add MailKite server-panel recipes (CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ A curated list of resources on Email tools, server, framework, technology...
 
 ### CLI
 - [Himalaya](https://github.com/soywod/himalaya) - CLI to manager email - `MIT`, `Rust`
+- [MailKite server-panel recipes](https://github.com/mailkite/forge) - One-command email wiring (SMTP relay + inbound webhook) for Laravel Forge, Ploi & RunCloud sites - `MIT`, `Node.js`
 
 ## Security
 


### PR DESCRIPTION
Adds one entry under **Sending → CLI**.

**[MailKite server-panel recipes](https://github.com/mailkite/forge)** — three small npm CLIs (`mailkite-forge`, `mailkite-ploi`, `mailkite-runcloud`) that wire MailKite email into Laravel Forge, Ploi, and RunCloud sites in one command: SMTP relay (or the native mailer) plus an optional inbound-email → webhook route. `MIT`, `Node.js`.

Follows the existing CLI entry format (name — description — license, language).