### PR TITLE
Add Agent Post Office inbox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ A curated list of resources on Email tools, server, framework, technology...
 
 ### Inbox API
 
+- [Agent Post Office](https://github.com/Agent-Post-Office/agentpostoffice-cloudflare) - Self-hosted custom-domain inbox API for AI agents on Cloudflare, with REST, CLI, MCP, threading, and attachment support. Developer preview. - `Apache-2.0`, `TypeScript`, `Cloudflare Workers`
+
 ### Forwarding
 
 - [Anonaddy](https://github.com/anonaddy/anonaddy) -  Anonymous email forwarding 


### PR DESCRIPTION
## Summary

Add Agent Post Office to the currently empty **Inbox API** section.

Agent Post Office is an Apache-2.0, TypeScript-based custom-domain inbox API for AI agents. It runs on Cloudflare and exposes REST, CLI, and MCP interfaces with threading and attachment support. The project is currently in developer preview.

## Verification

- `git diff --check`
- Confirmed the GitHub repository and project website both return HTTP 200.
