### PR TITLE
Add MailKite Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [MailCrab](https://github.com/tweedegolf/mailcrab) - Email test server for development, written in Rust - `Apache License`, `Rust`
 - [MailPit](https://github.com/axllent/mailpit) - An email and SMTP testing tool with API for developers  - `MIT`, `Go`
 - [Robin](https://github.com/mimecast/robin) -  Debug and development tool for MTA architects! Robin is a highly configurable SMTP client for testing and debugging SMTP servers. - `Java`, `Apache License 2.0`
+- [MailKite Server](https://github.com/mailkite/server) - Programmable mail server for apps and AI agents: Haraka-based SMTP (MX + submission), IMAP server, SQLite backend and web console; self-hosted via Docker Compose - `AGPL-3.0`, `Nodejs`
 
 ### Inbound - Mail Parser
 


### PR DESCRIPTION
Adds one entry under **Server → Complete Email Server**.

**[MailKite Server](https://github.com/mailkite/server)** — an open-source (AGPL-3.0) programmable mail server: Haraka-based SMTP (MX + submission), an IMAP server, a zero-dependency SQLite backend, and a web console. Fully self-hostable on any Node ≥ 22.5 host with `docker compose up -d` — no external service required.

Note: a previous PR of mine (#32) was rightly closed because it was a gateway to a hosted service. This one is different — it is the standalone open-source server itself; the SQLite backend ships in the repo and nothing depends on a SaaS. Being transparent: the project is new (first release August 2026) and pre-1.0. Follows the existing entry format.