### PR TITLE
Add email-server to Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [PHPMailer](https://github.com/PHPMailer/PHPMailer) -  The classic email sending library for PHP
 - [Anymail](https://github.com/anymail/django-anymail/) - Django email backends and webhooks for multiple ESP - `BSD 3-Clause`, `Python`
 - [Swoosh](https://github.com/swoosh/swoosh) -  Compose, deliver and test your emails easily in Elixir - `MIT`, `Elixir`
+- [email-server](https://github.com/colocohen/email-server) - Complete mail stack in one package: SMTP, IMAP and POP3 — server and client — with DKIM, SPF, DMARC and MTA-STS built in. Bring your own storage. - `Apache 2.0`, `Nodejs`
 
 ### Other
 


### PR DESCRIPTION
Adds `email-server` to the Library section.

A Node.js library implementing SMTP, IMAP and POP3 - server *and* client for
each - with DKIM, SPF, DMARC, MTA-STS, TLS-RPT and DSN built in. It is a
protocol layer only: storage is provided by the application, so it can back
onto SQLite, Postgres, S3 or anything else.

Closest existing entry is MailKit (.NET); there is currently no equivalent for
Node.js - nodemailer is SMTP send-only, and Haraka is an MTA rather than a
library.

Apache-2.0, one runtime dependency.