### PR TITLE
Add DMARC Analyzer to DMARC

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ A curated list of resources on Email tools, server, framework, technology...
 - [dmarcts-report-parser](https://github.com/techsneeze/dmarcts-report-parser) -  A Perl based tool to parse DMARC reports from an IMAP mailbox or from the filesystem, and insert the information into a database. ( Formerly known as imap-dmarcts ) - `GNU GPL v3`, `Perl`
 - [checkdmarc](https://github.com/domainaware/checkdmarc) -  A parser for SPF and DMARC DNS records - `Apache License version 2.0`, `Python`
 - [Viesti-Reports](https://github.com/antedebaas/Viesti-Reports) - DMARC & SMTP-TLS Reports processor and visualizer and BIMI file hoster - `GPL v2`, `PHP`
+- [DMARC Analyzer](https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp) -  Self-hosted DMARC aggregate report monitoring with per-client dashboards and multi-tenant separation; also ingests MTA-STS and TLS-RPT reports  - `Apache License version 2.0`, `C#`
 
 
 ### Privacy


### PR DESCRIPTION
Adding [DMARC Analyzer](https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp)
to the DMARC section.

**What it is:** a self-hosted application that collects DMARC aggregate reports
from a mailbox, parses them, and charts them per domain. It is multi-tenant —
domains are grouped per client, with per-client access — which is aimed at
agencies and MSPs running DMARC for many domains at once. It also ingests
MTA-STS and TLS-RPT reports alongside DMARC.

**Meets the list's bar:**

- Apache-2.0, source on GitHub
- Actively developed — 9 tagged releases, currently 0.9.0
- Runs anywhere Docker does: a published image, a Docker Compose file, and a
  Helm chart on Artifact Hub
- Report data stays on the operator's own infrastructure

The entry follows the existing format in the section, including the
license/language suffix:

```
- [DMARC Analyzer](https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp) -  Self-hosted DMARC aggregate report monitoring with per-client dashboards and multi-tenant separation; also ingests MTA-STS and TLS-RPT reports  - `Apache License version 2.0`, `C#`
```

Happy to reword or move it if you would rather it sat elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)