### PR TITLE
Include Reloop in Email API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ A curated list of resources on Email tools, server, framework, technology...
 ### Email API
 
 - [Hyvor](https://github.com/hyvor/) - `GNU AGPLv3`, `php`, `symfony`, `go`, `SvelteKit`, `Postgresql`
+- [Reloop](https://github.com/reloop-labs/reloop) - Send and receive email with a REST API and SMTP. Alternative to Resend, SendGrid, and Postmark.
 
 ## Code
 


### PR DESCRIPTION
**What is Reloop?**

Reloop is a transactional email API and SMTP service built for developers and AI agents.

**What does this PR add?**

Adds Reloop to the outgoing email services list as a modern alternative to SendGrid and Mailchimp — specifically built for developers who are building AI-native applications.

**Why Reloop?**

Simple API — plug and send, no unnecessary setup
Built for AI agents and automated workflows
Reliable open-loop email infrastructure
SMTP support for developers who prefer it

**Links**
Website: https://reloop.sh/
Docs: https://reloop.sh/docs